### PR TITLE
Fixes Usage of ConvertFrom-SecureString for PowerShell 5

### DIFF
--- a/source/private/Invoke-ProGet.ps1
+++ b/source/private/Invoke-ProGet.ps1
@@ -42,7 +42,7 @@ function Invoke-ProGet {
             Method               = $Method
             ContentType          = $ContentType
             Headers              = @{
-                'X-ApiKey' = ConvertFrom-SecureString $Configuration.ApiKey -AsPlainText
+                'X-ApiKey' = ([System.Net.NetworkCredential]::new("ApiKey", $Configuration.ApiKey)).Password
             }
             Verbose              = $false
         }

--- a/source/public/Assets/New-ProGetAsset.ps1
+++ b/source/public/Assets/New-ProGetAsset.ps1
@@ -144,7 +144,7 @@ function New-ProGetAsset {
                     $req = [System.Net.WebRequest]::CreateHttp("$($Configuration.EndpointUrl)$($RequestParams.Slug)?multipart=upload&id=$uuid&index=$index&offset=$offset&totalSize=$fileLength&partSize=$currentChunkSize&totalParts=$totalParts")
                     $req.Method = 'POST'
                     Write-Verbose "[$($req.Method)] $($req.RequestUri)"
-                    $req.Headers.Add("X-ApiKey", (ConvertFrom-SecureString $Configuration.ApiKey -AsPlainText))
+                    $req.Headers.Add("X-ApiKey", ([System.Net.NetworkCredential]::new("ApiKey", $Configuration.ApiKey)).Password)
                     $req.ContentLength = $currentChunkSize
                     $req.AllowWriteStreamBuffering = $false
                     $reqStream = $req.GetRequestStream()
@@ -162,7 +162,7 @@ function New-ProGetAsset {
                 $req = [System.Net.WebRequest]::CreateHttp("$($Configuration.EndpointUrl)$($RequestParams.Slug)?multipart=complete&id=$uuid")
                 $req.Method = 'POST'
                 Write-Verbose "[$($req.Method)] $($req.RequestUri)"
-                $req.Headers.Add("X-ApiKey", (ConvertFrom-SecureString $Configuration.ApiKey -AsPlainText))
+                $req.Headers.Add("X-ApiKey", ([System.Net.NetworkCredential]::new("ApiKey", $Configuration.ApiKey)).Password)
                 $req.ContentLength = 0
                 try {
                     $response = $req.GetResponse()


### PR DESCRIPTION
-AsPlainText isn't available in PowerShell 5, so this change hopefully makes the module compatible again.